### PR TITLE
fix issue for multiple attributes with same name (crashed the import)

### DIFF
--- a/library/talipot-python/plugins/import/GraphMLImport.py
+++ b/library/talipot-python/plugins/import/GraphMLImport.py
@@ -72,7 +72,7 @@ class GraphMLHandler(xml.sax.ContentHandler):
 
                 # Create a Talipot property compatible with the attribute type
                 while self.graph.existProperty(attrName):
-                    attrName = '_'+attrName
+                    attrName = attrName+'_'+attrType
 
                 self.getGraphProperty(self.currentAttrId, attrName, attrType)
                 # save attributes info for later use

--- a/library/talipot-python/plugins/import/GraphMLImport.py
+++ b/library/talipot-python/plugins/import/GraphMLImport.py
@@ -72,7 +72,7 @@ class GraphMLHandler(xml.sax.ContentHandler):
 
                 # Create a Talipot property compatible with the attribute type
                 while self.graph.existProperty(attrName):
-                    attrName = attrName+'_'+attrType
+                    attrName = attrName + '_' + attrType
 
                 self.getGraphProperty(self.currentAttrId, attrName, attrType)
                 # save attributes info for later use

--- a/library/talipot-python/plugins/import/GraphMLImport.py
+++ b/library/talipot-python/plugins/import/GraphMLImport.py
@@ -71,6 +71,9 @@ class GraphMLHandler(xml.sax.ContentHandler):
                     self.attrLabel = 'label'
 
                 # Create a Talipot property compatible with the attribute type
+                while self.graph.existProperty(attrName):
+                    attrName = '_'+attrName
+
                 self.getGraphProperty(self.currentAttrId, attrName, attrType)
                 # save attributes info for later use
                 self.attributes[attrs['id']] = {'name': attrName,

--- a/library/talipot-python/plugins/import/GraphMLImport.py
+++ b/library/talipot-python/plugins/import/GraphMLImport.py
@@ -71,8 +71,8 @@ class GraphMLHandler(xml.sax.ContentHandler):
                     self.attrLabel = 'label'
 
                 # Create a Talipot property compatible with the attribute type
-                while self.graph.existProperty(attrName):
-                    attrName = '_'+attrName
+                if self.graph.existProperty(attrName):
+                    attrName += '_' + attrType
 
                 self.getGraphProperty(self.currentAttrId, attrName, attrType)
                 # save attributes info for later use

--- a/library/talipot-python/plugins/import/GraphMLImport.py
+++ b/library/talipot-python/plugins/import/GraphMLImport.py
@@ -71,7 +71,7 @@ class GraphMLHandler(xml.sax.ContentHandler):
                     self.attrLabel = 'label'
 
                 # Create a Talipot property compatible with the attribute type
-                while self.graph.existProperty(attrName):
+                if self.graph.existProperty(attrName):
                     attrName += '_' + attrType
 
                 self.getGraphProperty(self.currentAttrId, attrName, attrType)

--- a/library/talipot-python/plugins/import/GraphMLImport.py
+++ b/library/talipot-python/plugins/import/GraphMLImport.py
@@ -72,7 +72,7 @@ class GraphMLHandler(xml.sax.ContentHandler):
 
                 # Create a Talipot property compatible with the attribute type
                 while self.graph.existProperty(attrName):
-                    attrName = attrName + '_' + attrType
+                    attrName += '_' + attrType
 
                 self.getGraphProperty(self.currentAttrId, attrName, attrType)
                 # save attributes info for later use

--- a/tests/plugins/data/same_attribute_multiple_type.graphml
+++ b/tests/plugins/data/same_attribute_multiple_type.graphml
@@ -1,0 +1,375 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
+         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<!-- Created by igraph -->
+  <key id="v__a" for="node" attr.name="_a" attr.type="double"/>
+  <key id="v__t" for="node" attr.name="_t" attr.type="double"/>
+  <key id="v__q" for="node" attr.name="_q" attr.type="double"/>
+  <key id="v__r" for="node" attr.name="_r" attr.type="double"/>
+  <key id="e__t" for="edge" attr.name="_t" attr.type="boolean"/>
+  <graph id="G" edgedefault="undirected">
+    <node id="n0">
+      <data key="v__q">0</data>
+      <data key="v__r">0</data>
+    </node>
+    <node id="n1">
+      <data key="v__q">1</data>
+      <data key="v__r">0</data>
+    </node>
+    <node id="n2">
+      <data key="v__q">2</data>
+      <data key="v__r">0</data>
+    </node>
+    <node id="n3">
+      <data key="v__q">3</data>
+      <data key="v__r">0</data>
+    </node>
+    <node id="n4">
+      <data key="v__q">4</data>
+      <data key="v__r">0</data>
+    </node>
+    <node id="n5">
+      <data key="v__a">0.25</data>
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">1</data>
+    </node>
+    <node id="n6">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">4</data>
+      <data key="v__r">2</data>
+    </node>
+    <node id="n7">
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">2</data>
+    </node>
+    <node id="n8">
+      <data key="v__t">1</data>
+      <data key="v__q">-1</data>
+      <data key="v__r">4</data>
+    </node>
+    <node id="n9">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">2</data>
+      <data key="v__r">4</data>
+    </node>
+    <node id="n10">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">4</data>
+      <data key="v__r">6</data>
+    </node>
+    <node id="n11">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">6</data>
+    </node>
+    <node id="n12">
+      <data key="v__t">1</data>
+      <data key="v__q">-1</data>
+      <data key="v__r">7</data>
+    </node>
+    <node id="n13">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">9</data>
+    </node>
+    <node id="n14">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">1</data>
+      <data key="v__r">11</data>
+    </node>
+    <node id="n15">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">13</data>
+    </node>
+    <node id="n16">
+      <data key="v__t">1</data>
+      <data key="v__q">-1</data>
+      <data key="v__r">15</data>
+    </node>
+    <node id="n17">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">1</data>
+      <data key="v__r">15</data>
+    </node>
+    <node id="n18">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">0</data>
+      <data key="v__r">17</data>
+    </node>
+    <node id="n19">
+      <data key="v__t">1</data>
+      <data key="v__q">-1</data>
+      <data key="v__r">20</data>
+    </node>
+    <node id="n20">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">20</data>
+    </node>
+    <node id="n21">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">2</data>
+      <data key="v__r">22</data>
+    </node>
+    <node id="n22">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">4</data>
+      <data key="v__r">24</data>
+    </node>
+    <node id="n23">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">24</data>
+    </node>
+    <node id="n24">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">2</data>
+      <data key="v__r">25</data>
+    </node>
+    <node id="n25">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">27</data>
+    </node>
+    <node id="n26">
+      <data key="v__t">1</data>
+      <data key="v__q">-1</data>
+      <data key="v__r">30</data>
+    </node>
+    <node id="n27">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">1</data>
+      <data key="v__r">30</data>
+    </node>
+    <node id="n28">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">32</data>
+    </node>
+    <node id="n29">
+      <data key="v__t">1</data>
+      <data key="v__q">0</data>
+      <data key="v__r">32</data>
+    </node>
+    <node id="n30">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">1</data>
+      <data key="v__r">34</data>
+    </node>
+    <node id="n31">
+      <data key="v__a">0</data>
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">36</data>
+    </node>
+    <node id="n32">
+      <data key="v__t">1</data>
+      <data key="v__q">0</data>
+      <data key="v__r">36</data>
+    </node>
+    <node id="n33">
+      <data key="v__a">1.75</data>
+      <data key="v__t">1</data>
+      <data key="v__q">3</data>
+      <data key="v__r">37</data>
+    </node>
+    <node id="n34">
+      <data key="v__q">0</data>
+      <data key="v__r">39</data>
+    </node>
+    <node id="n35">
+      <data key="v__q">2</data>
+      <data key="v__r">39</data>
+    </node>
+    <node id="n36">
+      <data key="v__q">3</data>
+      <data key="v__r">39</data>
+    </node>
+    <node id="n37">
+      <data key="v__q">4</data>
+      <data key="v__r">39</data>
+    </node>
+    <edge source="n3" target="n5">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n5" target="n7">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n6" target="n7">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n2" target="n9">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n8" target="n9">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n7" target="n11">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n10" target="n11">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n11" target="n12">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n1" target="n14">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n14" target="n17">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n16" target="n17">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n19" target="n20">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n22" target="n23">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n21" target="n24">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n17" target="n27">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n26" target="n27">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n18" target="n29">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n28" target="n29">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n27" target="n30">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n29" target="n32">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n31" target="n32">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n31" target="n33">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n32" target="n34">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n4" target="n6">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n22" target="n37">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n33" target="n36">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n6" target="n9">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n11" target="n13">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n13" target="n15">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n14" target="n15">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n15" target="n17">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n18" target="n20">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n24" target="n25">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n23" target="n25">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n27" target="n28">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n28" target="n30">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n6" target="n9">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n17" target="n20">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n15" target="n17">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n10" target="n22">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n20" target="n22">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n21" target="n22">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n28" target="n30">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n30" target="n31">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n27" target="n28">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n9" target="n13">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n13" target="n21">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n13" target="n14">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n0" target="n15">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n17" target="n18">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n10" target="n20">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n23" target="n24">
+      <data key="e__t">false</data>
+    </edge>
+    <edge source="n25" target="n35">
+      <data key="e__t">false</data>
+    </edge>
+  </graph>
+</graphml>


### PR DESCRIPTION
I had an issue with some generated graphml that contained multiple entries with the same name (and sometimes different types), which crashed the import. The fix only prepends '_'  to existing key names.